### PR TITLE
Added Pablo Stanley's avataaars library for Penpot

### DIFF
--- a/Avataaars-by-Pablo-Stanley.LICENSE
+++ b/Avataaars-by-Pablo-Stanley.LICENSE
@@ -1,0 +1,2 @@
+This penpot file contains assets licences by Pablo Stanley: Free for personal and commercial use.
+https://avataaars.com/


### PR DESCRIPTION
I decided to convert Pablo Stanley's Sketch library, avataaars, for Penpot.

Once Penpot is able to import Figma files and Sketch files, it will be a lot easier to convert their open source templates and libraries to Penpot as well.

Video tutorial can be found here: https://url.candide.media/avataaars-for-penpot-tutorial